### PR TITLE
Update CHANGELOG to reflect new Label Studio version 1.17.0

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.17.0
+- Upgraded Label Studio application version to 1.17.0
+
 ## 1.9.8
 ### Fixes
 * Add data dir as volume mount to db-migration initContainer and extra initContainers.


### PR DESCRIPTION
Update the `heartex/label-studio/CHANGELOG.md` file to reflect the new Label Studio version 1.17.0.