### PR TITLE
Revert "Update `appVersion`"

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 1.11.6
-- Update `appVersion` to `1.16.0`.
-
 ## 1.11.5
 - Loosen the readiness check thresholds in the app to support smaller environments.
 

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,9 +5,9 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.11.6
+version: 1.11.5
 # Label Studio release version
-appVersion: "1.21.0"
+appVersion: "1.20.0"
 kubeVersion: ">= 1.14.0-0"
 dependencies:
   - name: redis


### PR DESCRIPTION
Reverts Hirundo-io/label-studio-charts#5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the Helm chart and app version bump, and removes the 1.11.6 changelog entry.
> 
> - **Helm Chart (`heartex/label-studio/Chart.yaml`)**:
>   - Set `version` to `1.11.5` (was `1.11.6`).
>   - Set `appVersion` to `"1.20.0"` (was `"1.21.0"`).
> - **Changelog (`heartex/label-studio/CHANGELOG.md`)**:
>   - Remove `1.11.6` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbfe5f80baaff5cb8fd51118d14351451c5a1b32. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->