### PR TITLE
Revert "Revert "Update `appVersion`""

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.6
+- Update `appVersion` to `1.16.0`.
+
 ## 1.11.5
 - Loosen the readiness check thresholds in the app to support smaller environments.
 

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,9 +5,9 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.11.5
+version: 1.11.6
 # Label Studio release version
-appVersion: "1.20.0"
+appVersion: "1.21.0"
 kubeVersion: ">= 1.14.0-0"
 dependencies:
   - name: redis


### PR DESCRIPTION
Reverts Hirundo-io/label-studio-charts#6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Helm chart to 1.11.6, updates appVersion, and adds a 1.11.6 changelog entry.
> 
> - **Chart**:
>   - Update `heartex/label-studio/Chart.yaml`:
>     - `version` → `1.11.6`.
>     - `appVersion` → `"1.21.0"`.
> - **Changelog**:
>   - Add `1.11.6` section noting appVersion update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cf8e11ff744617caee0e0cc1e949e16d91c8c27. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->